### PR TITLE
Failing PR

### DIFF
--- a/apps/express-app/index.js
+++ b/apps/express-app/index.js
@@ -10,7 +10,6 @@ const port = process.env.PORT || 3000;
 logger.DEBUG(`${name} starting`);
 
 app.get('/', (_, res) => {
-  logger.FOO(`${name} running in env ${env}`);
   res.json({ ok: true, name, version });
 });
 

--- a/apps/express-app/index.js
+++ b/apps/express-app/index.js
@@ -10,6 +10,7 @@ const port = process.env.PORT || 3000;
 logger.DEBUG(`${name} starting`);
 
 app.get('/', (_, res) => {
+  logger.FOO(`${name} running in env ${env}`);
   res.json({ ok: true, name, version });
 });
 

--- a/packages/simple-logger/index.js
+++ b/packages/simple-logger/index.js
@@ -1,5 +1,4 @@
 const LEVELS = {
-  debug: 'DEBUG',
   info: 'INFO',
   warn: 'WARN',
   error: 'ERROR',
@@ -8,9 +7,6 @@ const LEVELS = {
 const logger = {
   _log: (level, text) => {
     console.log(`[${level}]: ${text}`);
-  },
-  DEBUG: (text) => {
-    logger._log(LEVELS.debug, text);
   },
   INFO: (text) => {
     logger._log(LEVELS.info, text);

--- a/packages/simple-logger/index.test.js
+++ b/packages/simple-logger/index.test.js
@@ -3,7 +3,6 @@ const { logger } = require('./index');
 describe('simple-logger', () => {
   test('it correctly exports the logger', () => {
     expect(logger).toHaveProperty('_log');
-    expect(logger).toHaveProperty('DEBUG');
     expect(logger).toHaveProperty('INFO');
     expect(logger).toHaveProperty('WARN');
     expect(logger).toHaveProperty('ERROR');
@@ -12,8 +11,6 @@ describe('simple-logger', () => {
   test('it logs correctly', () => {
     const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => {});
 
-    logger.DEBUG('debug message');
-    expect(consoleMock).toHaveBeenCalledWith(`[DEBUG]: debug message`);
     logger.INFO('info message');
     expect(consoleMock).toHaveBeenCalledWith(`[INFO]: info message`);
     logger.WARN('warn message');


### PR DESCRIPTION
This PR fails due to a breaking change in `@monorepo/simple-logger` where the `DEBUG` method is removed from the logger. As such, the app `express-app` that calls this method on startup causes this build to fail. Note that the only changed file are files in `@monorepo/simple-logger`.